### PR TITLE
Validando o retorno do método Pix, evitando que ele retorne o 'Expira…

### DIFF
--- a/lib/Models/Payment/Pix.php
+++ b/lib/Models/Payment/Pix.php
@@ -7,31 +7,28 @@ namespace Safe2Pay\Models\Payment;
  *
  * @package Safe2Pay\Models
  */
-class Pix implements \JsonSerializable
-{
+class Pix implements \JsonSerializable {
 
     private $Expiration;
 
-    public function getExpiration()
-    {
+    public function getExpiration() {
         return $this->Expiration;
     }
 
-    public function setExpiration($Expiration)
-    {
+    public function setExpiration($Expiration) {
         $this->Expiration = $Expiration;
     }
 
-    function __construct($Expiration = null)
-    {
+    function __construct($Expiration = null) {
         $this->Expiration = $Expiration;
     }
 
-    public function jsonSerialize()
-    {
-        return [
-            "Expiration" => $this->Expiration
-        ];
+    public function jsonSerialize() {
+        $object = [];
+        if (!empty(( $this->Expiration))) {
+            $object['Expiration'] = $this->Expiration;
+        }
+        return $object;
     }
 
 }


### PR DESCRIPTION
Este ajuste impede que, ao usuário escolher o método de pagamento PIX sem informar o prazo de expiração, o parâmetro 'Expiration' retorne o valor nulo, que anteriormente resultava no seguinte erro: 'Não foi possível realizar a operação. A estrutura do objeto informado está incorreta.'